### PR TITLE
fix: hackily remove checkit() procedure and triggers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,3 +15,7 @@ RUN wget https://github.com/mikefarah/yq/releases/download/v4.12.2/yq_linux_amd6
 RUN apt-get install -y libdbd-mysql-perl mysql-client build-essential perl perl-doc \
     && apt-get install -y cpanminus \
     && cpanm --notest DWHEELER/App-Sqitch-$SQITCH_VERSION.tar.gz
+
+# Hacky way to fix log_bin_trust_function_creators errors
+RUN wget https://gist.githubusercontent.com/qoharu/8c97a996efbf0bd8b8361d5483aa75d0/raw/e3e74a46c80d2e77211c7fd7dc55d7bf8909ae69/mysql.sql
+RUN mv mysql.sql /usr/local/share/perl/5.30.0/App/Sqitch/Engine/mysql.sql


### PR DESCRIPTION
replace mysql template with commented checkit() and triggers

```
ERROR 1419 (HY000) at line 158 in file: '/usr/local/share/perl/5.30.0/App/Sqitch/Engine/mysql.sql': You do not have the SUPER privilege and binary logging is enabled (you *might* want to use the less safe log_bin_trust_function_creators variable)

```